### PR TITLE
Update heat_furnace.lua

### DIFF
--- a/exotic-space-industries-remembrance/prototypes/steam_age/heat_furnace.lua
+++ b/exotic-space-industries-remembrance/prototypes/steam_age/heat_furnace.lua
@@ -10,10 +10,38 @@ heat_furnace_entity.energy_source = {
   max_transfer = '10MW',
   emissions_per_minute = { pollution = 1.25 },
   connections = {
-      {position = { -1.0,  0.0 }, direction = defines.direction.west},
-      {position = {  0.0,  1.0 }, direction = defines.direction.south},
-      {position = {  1.0,  0.0 }, direction = defines.direction.east},
-      {position = {  0.0, -1.0 }, direction = defines.direction.north}
+    {
+      position = {-0.5, -0.5},
+      direction = defines.direction.north
+    },
+    {
+      position = {-0.5, -0.5},
+      direction = defines.direction.west
+    },
+    {
+      position = {0.5, -0.5},
+      direction = defines.direction.north
+    },
+    {
+      position = {0.5, -0.5},
+      direction = defines.direction.east
+    },
+    {
+      position = {-0.5, 0.5},
+      direction = defines.direction.south
+    },
+    {
+      position = {-0.5, 0.5},
+      direction = defines.direction.west
+    },
+    {
+      position = {0.5, 0.5},
+      direction = defines.direction.south
+    },
+    {
+      position = {0.5, 0.5},
+      direction = defines.direction.east
+    },
   }
 }
 


### PR DESCRIPTION
The connections weren't working properly because the object was 2x2 and not 3x3. The coordinates 1,0, and -1 define a 3x3. If the object has even size (2,4,6) it's connections need to be at -0.5 -> 0.5

Also, I added connections for all spots. Because it's not a 3x3 mirroring / rotating might not work if the spots don't exist on all spots.

With this change applied it works like this

<img width="209" height="206" alt="kuva" src="https://github.com/user-attachments/assets/93806fc8-45e8-49f5-8b28-13c3298d2cf5" />
